### PR TITLE
Escape @ to avoid HTML tags in title

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   output-dir: docs
 
 website:
-  title: "The Poldrack Lab @Stanford"
+  title: "The Poldrack Lab \\@Stanford"
   repo-url: https://github.com/poldracklab/poldracklab.github.io
   repo-actions: [edit, issue] 
   google-analytics: "379246033"


### PR DESCRIPTION
Before:

![image](https://github.com/poldracklab/poldracklab.github.io/assets/83442/8a57cd7d-7236-4499-a653-054eca26f38a)

After:

![image](https://github.com/poldracklab/poldracklab.github.io/assets/83442/b681e6ac-913e-410c-a5cf-46a1231e7ce3)

Does not add spurious backslash to title in other pages.