### PR TITLE
ENH: Add bootstrap icons for links, add GitHub as demo

### DIFF
--- a/people.ejs
+++ b/people.ejs
@@ -9,7 +9,15 @@
     if (member.website) { %></a><% }
     for (const [link, field] of Object.entries(templateParams)) {
       if (member[link]) {
-      %> <a href="<%- field.base_url %><%- member[link] %>"><img src="<%- field.icon %>" alt="<%- field.alt %>"></a><%
+      %> <a style="color: inherit;" href="<%- field.base_url %><%- member[link] %>"><%
+        if (field.icon) {
+          %><img src="<%- field.icon %>" alt="<%- field.alt ? field.alt : link %>"><%
+        } else {
+          %><i class="bi bi-<%- link %>" role="img" aria-label="<%-
+            field.alt ? field.alt : link
+          %>"></i><%
+        }
+      %></a><%
       }
     }
   %></li>

--- a/people.md
+++ b/people.md
@@ -14,6 +14,8 @@ listing:
       base_url: https://orcid.org/
       icon: https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png
       alt: ORCID
+    github:
+      base_url: https://github.com/
 format:
   html:
     page-layout: full

--- a/people.yml
+++ b/people.yml
@@ -4,6 +4,7 @@
   - name: Russ Poldrack
     website: https://poldrack.github.io
     orcid: 0000-0001-6755-0259
+    github: poldrack
 
 - group: Research Scientists
   members:


### PR DESCRIPTION
Turned out not to be painful. I just don't understand what Quarto's doing with their CSS and using `<i>` tags for images, but I don't need to understand to copy.

Not sure if you actually want to link GitHub, but this looks like:

![image](https://github.com/poldracklab/poldracklab.github.io/assets/83442/060f89f9-927f-40b0-9ca6-27c82ea47170)
